### PR TITLE
updated make file; paths and added make rebuild-clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ rebuild:
 	@docker compose build --no-cache
 	@docker compose up -d
 
+# Completely clean up Docker environment and rebuild containers from scratch
+rebuild-clean:
+	@docker compose down -v --remove-orphans --rmi all
+	@docker compose build --no-cache
+	@docker compose up -d
+
 # Stop the containers gracefully
 stop:
 	@docker compose down
@@ -20,9 +26,9 @@ exec-pythonbase:
 exec-postgres:
 	@docker compose exec pgduckdb psql -U postgres -d postgres
 
-# # Execute a DuckDB shell
+# Execute a DuckDB shell
 exec-duckdb:
-	@docker compose exec pythonbase ./duckdb
+	@docker compose exec pythonbase /usr/local/bin/duckdb
 
 # Execute a shell inside the linuxbase container
 exec-linuxbase:
@@ -30,13 +36,11 @@ exec-linuxbase:
 
 # Load data into PostgreSQL
 load-db:
-	@docker compose exec -e PYTHONPATH=/apps pythonbase python -m ingest_claims.load_claims_to_db
-
+	@docker compose exec -e PYTHONPATH=/apps pythonbase /venv/bin/python -m ingest_claims.load_claims_to_db
 
 # Verify data in PostgreSQL
 verify-db:
 	@docker compose exec pgduckdb psql -U postgres -d postgres -c "SELECT COUNT(*) FROM raw_claims;"
-
 
 # Check the running containers
 status:
@@ -57,7 +61,6 @@ backup-db:
 # Restore the PostgreSQL database from a backup file
 restore-db:
 	@cat backup.sql | docker compose exec -T pgduckdb psql -U postgres -d postgres
-
 
 # Run all tests inside the container
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # Set up the project with Docker Compose
 setup:
+	@docker compose build linuxbase
+	@docker compose build pythonbase
 	@docker compose build
 	@docker compose up -d
 
@@ -11,7 +13,9 @@ rebuild:
 # Completely clean up Docker environment and rebuild containers from scratch
 rebuild-clean:
 	@docker compose down -v --remove-orphans --rmi all
-	@docker compose build --no-cache
+	@docker compose build --no-cache linuxbase
+	@docker compose build --no-cache pythonbase
+	@docker compose build
 	@docker compose up -d
 
 # Stop the containers gracefully


### PR DESCRIPTION
This PR improves the project's `Makefile`, primarily focusing on clarity, robustness, and ease of use:

## Key Changes:
- **New Command `make rebuild-clean`:**
  - Performs a thorough cleanup by removing containers, volumes, orphaned resources, and images (`docker compose down -v --remove-orphans --rmi all`).
  - Completely rebuilds the environment without caching (`docker compose build --no-cache`).
  - Starts up containers fresh (`docker compose up -d`).
  - Ensures a clean, reproducible environment, especially helpful for troubleshooting or ensuring consistency.

- **Path Updates:**
  - Updated the executable paths explicitly:
    - DuckDB execution changed from `./duckdb` to absolute path `/usr/local/bin/duckdb`.
    - Python commands explicitly use the virtual environment (`/venv/bin/python`), ensuring consistent environment isolation and correct execution.

## Benefits:
- Guarantees reproducible builds and runs.
- Eliminates potential environment conflicts or stale states.
- Clarifies script execution paths, improving maintainability and reducing errors.