### PR TITLE
updated paths for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,12 +85,12 @@ restore-db:
 
 # Run all tests inside the container
 test:
-	@docker compose exec -e PYTHONPATH=/apps pythonbase pytest -v /apps/tests
+	@docker compose exec -e PYTHONPATH=/apps pythonbase /venv/bin/pytest -v /apps/tests
 
 # Run only unit tests
 test-unit:
-	@docker compose exec -e PYTHONPATH=/apps pythonbase pytest /apps/tests/unit
+	@docker compose exec -e PYTHONPATH=/apps pythonbase /venv/bin/pytest /apps/tests/unit
 
 # Run only integration tests
 test-integration:
-	@docker compose exec -e PYTHONPATH=/apps pythonbase pytest /apps/tests/integration
+	@docker compose exec -e PYTHONPATH=/apps pythonbase /venv/bin/pytest /apps/tests/integration


### PR DESCRIPTION
This PR updates the paths for test executions in the project's `Makefile`, ensuring tests are consistently run within the project's isolated Python environment (`venv`):

## Key Changes:
- **Explicit Virtual Environment Usage:**
  - Changed test execution commands from using the default system-wide `pytest` to explicitly using `/venv/bin/pytest`.
  - Ensures all test commands (`make test`, `make test-unit`, and `make test-integration`) consistently utilize the correct Python environment.

## Benefits:
- Prevents potential issues arising from differences between system-wide and project-specific Python environments.
- Guarantees consistency, reproducibility, and reliability of test runs.
- Reduces the likelihood of environment-related errors during test execution.